### PR TITLE
Fixed "how to use" instructions to work for user lixz789

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ Ubuntu: sudo apt-get install git build-essential
 ```
 $ mkdir ~/src
 $ cd ~/src
-$ git clone https://github.com/Myria-de/mt7610u_wifi_sta_v3002_dpo_20130916.git
+$ git clone https://github.com/lixz789/mt7610u_wifi_sta_v3002_dpo_20130916.git
 $ make
 $ make install
-$ cp RT2870STA.dat  /etc/Wireless/RT2870STA/RT2870STA.dat
 $ reboot
 ```
 refer to：


### PR DESCRIPTION
Hey dude. You seem to have forgot to update the instructions in the readme after you forked the repository. It took me a while to spot it, and I was close to simply give up... 

More specifically, the clone path has not been updated, and the step which copies the .dat file is not needed.

I fixed it for you, so you can just pull it if you like the changes
