### PR TITLE
Update README.md to fix instructions for compile error in kernel 5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ rpi-source
 $ mkdir ~/src
 $ cd ~/src
 $ git clone https://github.com/lixz789/mt7610u_wifi_sta_v3002_dpo_20130916.git
+$ cd mt7610u_wifi_sta_v3002_dpo_20130916
 $ sudo ARCH=arm make -j4
 $ sudo ARCH=arm make installfw
 $ sudo insmod mt7610u.ko

--- a/README.md
+++ b/README.md
@@ -15,13 +15,34 @@ Modified usb wifi driver for TP-Link TL-WDN5200 AC600 T2U and Cisco Linksys AE60
 #prepare
 Ubuntu: sudo apt-get install git build-essential
 
+#prepare kernel source code
+..if you get this error: no rule, for target „arch/arm/tools/syscall.tbl“, 
+  needed from „arch/arm/include/generated/uapi/asm/unistd-common.h“
+  
+  For new kernel versions 5+ you need to download the latest rpi-sources to fix it:
+
+$ sudo wget https://raw.githubusercontent.com/notro/rpi-source/master/rpi-source -O /usr/bin/rpi-source
+$ sudo chmod +x /usr/bin/rpi-source
+$ /usr/bin/rpi-source -q --tag-update
+$ rpi-source
+ 
+ if you get any question just answer with [y]
+
+
 # how to use
 ```
 $ mkdir ~/src
 $ cd ~/src
-$ git clone https://github.com/Myria-de/mt7610u_wifi_sta_v3002_dpo_20130916.git
-$ make
-$ make install
+$ git clone https://github.com/lixz789/mt7610u_wifi_sta_v3002_dpo_20130916.git
+$ sudo ARCH=arm make -j4
+$ sudo ARCH=arm make installfw
+$ sudo insmod mt7610u.ko
+  or
+  sudo insmod mt7630u.ko
+  or
+  sudo insmod mt7650u.ko
+  
+$ sudo ARCH=arm make install
 $ cp RT2870STA.dat  /etc/Wireless/RT2870STA/RT2870STA.dat
 $ reboot
 ```


### PR DESCRIPTION
Fixed instructions for compiling on new kernel versions. (5+)  
Tested on raspberry pi zero w:
uname -a
Linux pi 5.4.51+ #1327 Thu Jul 23 10:53:06 BST 2020 armv6l GNU/Linux


#1 fixes error

error: no rule, for target „arch/arm/tools/syscall.tbl“, 
  needed from „arch/arm/include/generated/uapi/asm/unistd-common.h“